### PR TITLE
Bloquea buscadores

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Objetivo

Se bloquea que los rastreadores indexen la página.

## Cómo probarlo

1. Lanza un `yarn start`
2. Dirígete a la url: http://localhost:4321/robots.txt
3. Comprueba que el `robots.txt` muestra el siguiente contenido
```
User-agent: *
Disallow: /
```