### PR TITLE
fix: ajusta botón de descargar

### DIFF
--- a/src/views/Home/Summary.module.scss
+++ b/src/views/Home/Summary.module.scss
@@ -6,123 +6,122 @@
 @import "../../styles/tools/functions.scss";
 
 .summary {
-    @include gridLayout;
-    @include fullWidthContainerLateralPadding;
+  @include gridLayout;
+  @include fullWidthContainerLateralPadding;
 
-    position: relative;
+  position: relative;
 
-    padding-top: var(--space-5xl);
-    padding-bottom: var(--space-5xl);
+  padding-top: var(--space-5xl);
+  padding-bottom: var(--space-5xl);
 
-    color: var(--background-default);
-    background-color: var(--background-primary-default);
+  color: var(--background-default);
+  background-color: var(--background-primary-default);
 
-    @include textFontM;
+  @include textFontM;
 
-    overflow-x: hidden;
-    z-index: 10;
+  overflow-x: hidden;
+  z-index: 10;
 }
 
 .summaryIntro {
+  margin-bottom: var(--space-l);
 
-    margin-bottom: var(--space-l);
+  grid-column: 1 / -1;
 
-    grid-column: 1 / -1;
+  @media #{$onlyTablet} {
+    grid-column: 3 / -1;
+  }
 
-    @media #{$onlyTablet} {
-        grid-column: 3 / -1;
-    }
+  @media #{$onlyLaptop} {
+    grid-column: 7 / -1;
+  }
 
-    @media #{$onlyLaptop} {
-        grid-column: 7 / -1;
-    }
-
-    @media #{$fromDesktop} {
-        grid-column: 7 / 12;
-    }
+  @media #{$fromDesktop} {
+    grid-column: 7 / 12;
+  }
 }
 
 .summaryImage {
-    position: absolute;
-    top: 30%;
-    left: 50%;
-    height: auto;
-    width: auto;
+  position: absolute;
+  top: 30%;
+  left: 50%;
+  height: auto;
+  width: auto;
 
-    transform: translateX(-50%);
-    z-index: -2;
+  transform: translateX(-50%);
+  z-index: -2;
 }
 
 .summaryTitle {
+  grid-column: 1 / -1;
+  margin-bottom: var(--space-3xl);
 
-    grid-column: 1 / -1;
-    margin-bottom: var(--space-3xl);
+  @include displayFontL;
+  text-transform: uppercase;
 
-    @include displayFontL;
-    text-transform: uppercase;
-
-    @media #{$fromTablet} {
-        grid-column: 2 / -1;
-    }
+  @media #{$fromTablet} {
+    grid-column: 2 / -1;
+  }
 }
 
 .summaryContent {
-    margin-bottom: var(--space-2xl);
+  margin-bottom: var(--space-2xl);
 
-    grid-column: 1 / -1;
+  grid-column: 1 / -1;
 
-    @media #{$onlyTablet} {
-        grid-column: 1 / 6;
-    }
+  @media #{$onlyTablet} {
+    grid-column: 1 / 6;
+  }
 
-    @media #{$onlyLaptop} {
-        grid-column: 1 / 7;
-    }
+  @media #{$onlyLaptop} {
+    grid-column: 1 / 7;
+  }
 
-    @media #{$fromDesktop} {
-        grid-column: 1 / 6;
-    }
+  @media #{$fromDesktop} {
+    grid-column: 1 / 6;
+  }
 }
 
 .actionsWrapper {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
-    margin-top: var(--space-5xl);
+  grid-column: 1 / -1;
+
+  margin-top: var(--space-5xl);
 }
 
 .hexagon {
-    height: #{toRem(56)};
+  height: #{toRem(56)};
 
-    @media #{$fromTablet} {
-        height: var(--space-5xl);
-    }
+  @media #{$fromTablet} {
+    height: var(--space-5xl);
+  }
 
-    @media #{$fromDesktop} {
-        height: var(--space-6xl);
-    }
-
+  @media #{$fromDesktop} {
+    height: var(--space-6xl);
+  }
 }
 
 .hexagon__top_left {
-    grid-column: 1 / -1;
+  grid-column: 1 / -1;
 }
 
 .hexagon__top_right {
-    grid-column: 4 / -1;
+  grid-column: 4 / -1;
 
-    @media #{$onlyTablet} {
-        grid-column: 7 / -1;
-    }
+  @media #{$onlyTablet} {
+    grid-column: 7 / -1;
+  }
 
-    @media #{$onlyLaptop} {
-        grid-column: 5 / -1;
-        margin-left: var(--space-3xl);
-    }
+  @media #{$onlyLaptop} {
+    grid-column: 5 / -1;
+    margin-left: var(--space-3xl);
+  }
 
-    @media #{$fromDesktop} {
-        grid-column: 5 / -1;
-        margin-left: var(--space-4xl);
-    }
+  @media #{$fromDesktop} {
+    grid-column: 5 / -1;
+    margin-left: var(--space-4xl);
+  }
 }


### PR DESCRIPTION
## Descripción
En la home, el segundo link de "Descargar BikoInsights # 6" no se estaba mostrando con el ancho adecuado.

![Captura de pantalla 2023-12-18 a las 10 45 21](https://github.com/biko2/insights-web/assets/58370877/7357012f-8159-4846-bf9d-b8492f3d35d4)

## Cómo probarlo
1. Lanza un `yarn start`
2. Dirígete a la url: [http://localhost:4321/](http://localhost:4321/)
3. Comprueba que el botón se muestra correctamente en las distintas resoluciones.